### PR TITLE
client: fix ESLint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ var/
 .installed.cfg
 *.egg
 node_modules/
+yarn.lock
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/client/package.json
+++ b/client/package.json
@@ -44,6 +44,7 @@
   "devDependencies": {
     "autoprefixer": "^6.3.7",
     "babel-core": "^6.23.1",
+    "babel-eslint": "^7.2.3",
     "babel-loader": "^6.3.2",
     "babel-plugin-react-transform": "^2.0.2",
     "babel-plugin-transform-object-assign": "^6.8.0",
@@ -55,6 +56,9 @@
     "cross-env": "^2.0.0",
     "css-loader": "^0.28.1",
     "dotenv": "^2.0.0",
+    "eslint": "^3.19.0",
+    "eslint-config-ascribe": "^3.0.1",
+    "eslint-plugin-import": "^2.2.0",
     "extract-text-webpack-plugin": "=2.0.0-beta.1",
     "file-loader": "^0.11.1",
     "node-sass": "^3.8.0",


### PR DESCRIPTION
Current setup might work if the required ESLint packages are installed globally but that should be discouraged. Currently, ESLint just complains about missing modules.

PR adds the required packages to the local dependencies so ESLint just works as expected after `npm install`.